### PR TITLE
Change required plug version.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule PlugStatsd.Mixfile do
 
   def project do
     [app: :plug_statsd,
-     version: "0.1.1",
+     version: "0.1.2",
      elixir: "~> 1.0",
      name: "plug_statsd",
      description: @description,
@@ -34,7 +34,7 @@ defmodule PlugStatsd.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [ {:plug, "~> 0.11.0"},
+    [ {:plug, ">= 0.11.0"},
       {:ex_statsd, ">= 0.5.0"},
     ]
   end


### PR DESCRIPTION
After updating to Phoenix 0.12, `mix deps.get` fails due to `plug_statsd`'s restriction to plug version `~0.11.0` which basically means `>= 0.11.0 and < 0.11.0`. This does not match new plug version is `0.12.1`:
http://elixir-lang.org/docs/stable/elixir/#!Version.html

This PR changes the dependency to `>= 0.11.0` and solves this problem.
