### PR TITLE
Support different backends

### DIFF
--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -97,7 +97,7 @@ defmodule Plug.Statsd do
   end
 
   defp backend(opts) do
-    case Keyword.get(:backend) do
+    case Keyword.get(opts, :backend) do
       :ex_statsd ->
         Plug.Statsd.ExStatsdBackend
       :statsderl ->

--- a/lib/plug_statsd/ex_statsd_backend.ex
+++ b/lib/plug_statsd/ex_statsd_backend.ex
@@ -1,0 +1,9 @@
+defmodule Plug.Statsd.ExStatsdBackend do
+  def increment(name, rate) do
+    ExStatsD.increment(name, sample_rate: rate)
+  end
+
+  def timing(name, elapsed, rate) do
+    ExStatsD.timer(elapsed, name, sample_rate: rate)
+  end
+end

--- a/lib/plug_statsd/statsderl_backend.ex
+++ b/lib/plug_statsd/statsderl_backend.ex
@@ -1,0 +1,9 @@
+defmodule Plug.Statsd.StatsderlBackend do
+  def increment(name, rate) do
+    :statsderl.increment(name, 1, rate)
+  end
+
+  def timing(name, elapsed, rate) do
+    :statsderl.timing(name, elapsed, rate)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule PlugStatsd.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :plug, :ex_statsd]]
+    [applications: [:logger, :plug]]
   end
 
   # Dependencies can be Hex packages:
@@ -34,8 +34,9 @@ defmodule PlugStatsd.Mixfile do
   #
   # Type `mix help deps` for more examples and options
   defp deps do
-    [ {:plug, ">= 0.11.0"},
+    [ {:plug, ">= 0.10.0"},
       {:ex_statsd, ">= 0.5.0"},
+      {:statsderl, github: "lpgauth/statsderl"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,3 @@
 %{"ex_statsd": {:hex, :ex_statsd, "0.5.0"},
-  "plug": {:hex, :plug, "0.11.3"}}
+  "plug": {:hex, :plug, "0.11.3"},
+  "statsderl": {:git, "git://github.com/lpgauth/statsderl.git", "3a4e1df11d082410d7bef642b38f18770baef52e", []}}


### PR DESCRIPTION
Hi,

I've added `statsderl` backend, and moved `ExStatsD` code into a backend on it's own. I've removed `ex_statsd` from applications, since it must be specified if you want `ex_statsd` or `statsderl` in your project.

The default backend is `ex_statsd` to keep it backwards compatible, but you can set it in config.

Example config:

``` elixir
config :plug_statsd, :backend, :statsderl
```
