### PR TITLE
Use conn.request_path instead of Plug.Conn.full_path.

### DIFF
--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -23,7 +23,7 @@ defmodule Plug.Statsd do
   end
 
   def uri(conn, opts) do
-    Plug.Conn.full_path(conn)
+    conn.request_path
     |> sanitize_uri(opts)
   end
 


### PR DESCRIPTION
`Plug.Conn.full_path` was deprecated in Plug 0.13.1 and removed in 0.14.0:

https://github.com/elixir-lang/plug/commit/04be449a3d77a9c93f4342040c49c1a8f4bfb001
https://github.com/elixir-lang/plug/commit/f14dd3904ed97c8d2a733d6bfcc51ef221fb6881
