### PR TITLE
add sanitize_uri function clause that matches on request paths withou…

### DIFF
--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -25,10 +25,9 @@ defmodule Plug.Statsd do
     |> sanitize_uri(opts)
   end
 
-  defp sanitize_uri("/", _opts) do
-    "[root]"
-  end
-  defp sanitize_uri("/"<>uri, opts) do
+  defp sanitize_uri("/", _opts), do: "[root]"
+  defp sanitize_uri("/"<>uri, opts), do: sanitize_uri(uri, opts)
+  defp sanitize_uri(uri, opts) do
     dot_replacement = Keyword.get(opts, :dot_replacement)
     slash_replacement = Keyword.get(opts, :slash_replacement)
 


### PR DESCRIPTION
…t a leading '/'

`conn.request_path` doesn't have a leading `/` for me, which is causing `FunctionClauseError`s. In order to solve this problem, I've added a function clause that will match on a URI without a leading `/`.
