### PR TITLE
Fix Elixir 1.5 warnings

### DIFF
--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -8,7 +8,7 @@ defmodule Plug.Statsd do
   @backend :ex_statsd
 
   def init(opts) do
-    Keyword.merge(default_options, opts)
+    Keyword.merge(default_options(), opts)
   end
   def call(conn, opts) do
     before_time = :os.timestamp()

--- a/lib/plug_statsd/ex_statsd_backend.ex
+++ b/lib/plug_statsd/ex_statsd_backend.ex
@@ -1,9 +1,11 @@
-defmodule Plug.Statsd.ExStatsdBackend do
-  def increment(name, rate) do
-    ExStatsD.increment(name, sample_rate: rate)
-  end
+if Code.ensure_loaded?(ExStatsD) do
+  defmodule Plug.Statsd.ExStatsdBackend do
+    def increment(name, rate) do
+      ExStatsD.increment(name, sample_rate: rate)
+    end
 
-  def timing(name, elapsed, rate) do
-    ExStatsD.timer(elapsed, name, sample_rate: rate)
+    def timing(name, elapsed, rate) do
+      ExStatsD.timer(elapsed, name, sample_rate: rate)
+    end
   end
 end

--- a/lib/plug_statsd/statsderl_backend.ex
+++ b/lib/plug_statsd/statsderl_backend.ex
@@ -1,9 +1,11 @@
-defmodule Plug.Statsd.StatsderlBackend do
-  def increment(name, rate) do
-    :statsderl.increment(name, 1, rate)
-  end
+if Code.ensure_loaded?(:statsderl) do
+  defmodule Plug.Statsd.StatsderlBackend do
+    def increment(name, rate) do
+      :statsderl.increment(name, 1, rate)
+    end
 
-  def timing(name, elapsed, rate) do
-    :statsderl.timing(name, elapsed, rate)
+    def timing(name, elapsed, rate) do
+      :statsderl.timing(name, elapsed, rate)
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -11,10 +11,10 @@ defmodule PlugStatsd.Mixfile do
      elixir: "~> 1.0",
      name: "plug_statsd",
      description: @description,
-     package: package,
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,4 @@
-%{"ex_statsd": {:hex, :ex_statsd, "0.5.3"},
-  "plug": {:hex, :plug, "1.1.3"},
+%{"ex_statsd": {:hex, :ex_statsd, "0.5.3", "e86dd97e25dbc80786e7d22b3c5537f2052a7e12daaaa7e6f2b9c34d03dbbd44", [], [], "hexpm"},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [], [], "hexpm"},
+  "plug": {:hex, :plug, "1.4.3", "236d77ce7bf3e3a2668dc0d32a9b6f1f9b1f05361019946aae49874904be4aed", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
   "statsderl": {:git, "https://github.com/lpgauth/statsderl.git", "9265c3d485dd80d3124082d53bbd41678822ec30", []}}


### PR DESCRIPTION
* Also add `Code.ensure_loaded?` checks to  backends
to get rid of compilation warnings