### PR TITLE
Add statix to list of supported backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ timing and count metrics to [statsd](https://github.com/etsy/statsd).
 This plug can currently can use either of two statsd backends:
  * [ex_statsd](https://github.com/CargoSense/ex_statsd)
  * [statsderl](https://github.com/lpgauth/statsderl)
+ * [statix](https://github.com/lexmag/statix)
 
 If you have additional statsd clients you'd like added, please open an [issue](https://github.com/jeffweiss/plug_statsd/issues/new)
 and let me know.


### PR DESCRIPTION
As said. It was originally done in #14, but I only found this out after doing a search against it.