### PR TITLE
Update 2018 07 30

### DIFF
--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -111,6 +111,8 @@ defmodule Plug.Statsd do
         Plug.Statsd.ExStatsdBackend
       :statsderl ->
         Plug.Statsd.StatsderlBackend
+      :nullstats ->
+        Plug.Statsd.NullStatsdBackend
       true ->
         raise ArgumentError, message: "Backend #{@backend} not found"
     end

--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -99,10 +99,10 @@ defmodule Plug.Statsd do
 
     backend(opts).increment(name, rate)
   end
-  defp send_metric({:histogram, name_elements, sample_rate: rate}, conn, opts, _elapsed) do
+  defp send_metric({:histogram, name_elements, sample_rate: rate}, conn, opts, elapsed) do
     name = metric_name(name_elements, conn, opts)
 
-    backend(opts).histogram(name, rate)
+    backend(opts).histogram(name, elapsed, rate)
   end
 
   defp backend(opts) do

--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -15,7 +15,7 @@ defmodule Plug.Statsd do
     conn
     |> Plug.Conn.register_before_send( fn conn ->
       after_time = :os.timestamp()
-      diff = div(:timer.now_diff(after_time, before_time), 1000)
+      diff = :timer.now_diff(after_time, before_time) / 1000.0
       send_metrics(conn, opts, diff)
       end)
   end

--- a/lib/plug_statsd.ex
+++ b/lib/plug_statsd.ex
@@ -99,6 +99,11 @@ defmodule Plug.Statsd do
 
     backend(opts).increment(name, rate)
   end
+  defp send_metric({:histogram, name_elements, sample_rate: rate}, conn, opts, _elapsed) do
+    name = metric_name(name_elements, conn, opts)
+
+    backend(opts).histogram(name, rate)
+  end
 
   defp backend(opts) do
     case Keyword.get(opts, :backend) do

--- a/lib/plug_statsd/ex_statsd_backend.ex
+++ b/lib/plug_statsd/ex_statsd_backend.ex
@@ -6,4 +6,8 @@ defmodule Plug.Statsd.ExStatsdBackend do
   def timing(name, elapsed, rate) do
     ExStatsD.timer(elapsed, name, sample_rate: rate)
   end
+
+  def histogram(name, elapsed, rate) do
+    ExStatsD.histogram(elapsed, name, sample_rate: rate)
+  end
 end

--- a/lib/plug_statsd/null_stats_backend.ex
+++ b/lib/plug_statsd/null_stats_backend.ex
@@ -1,0 +1,13 @@
+defmodule Plug.Statsd.NullStatsdBackend do
+  def increment(name, rate) do
+    nil
+  end
+
+  def timing(name, elapsed, rate) do
+    elapsed
+  end
+
+  def histogram(name, elapsed, rate) do
+    elapsed
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -11,10 +11,10 @@ defmodule PlugStatsd.Mixfile do
      elixir: "~> 1.0",
      name: "plug_statsd",
      description: @description,
-     package: package,
+     package: package(),
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application


### PR DESCRIPTION
Updating plug_statsd to use the newest version of the library, which includes Statix support(since ex_statsd has been deprecated).

Also added the `histogram` metric to the Statix backend to maintain ExStatsD parity.