### PR TITLE
Add tagging functionality

### DIFF
--- a/lib/plug_statsd/ex_statsd_backend.ex
+++ b/lib/plug_statsd/ex_statsd_backend.ex
@@ -1,14 +1,14 @@
 if Code.ensure_loaded?(ExStatsD) do
   defmodule Plug.Statsd.ExStatsdBackend do
-    def increment(name, rate) do
+    def increment(name, rate, _tags) do
       ExStatsD.increment(name, sample_rate: rate)
     end
 
-    def timing(name, elapsed, rate) do
+    def timing(name, elapsed, rate, _tags) do
       ExStatsD.timer(elapsed, name, sample_rate: rate)
     end
 
-    def histogram(name, elapsed, rate) do
+    def histogram(name, elapsed, rate, _tags) do
       ExStatsD.histogram(elapsed, name, sample_rate: rate)
     end
   end

--- a/lib/plug_statsd/null_stats_backend.ex
+++ b/lib/plug_statsd/null_stats_backend.ex
@@ -1,13 +1,13 @@
 defmodule Plug.Statsd.NullStatsdBackend do
-  def increment(_name, _rate) do
+  def increment(_name, _rate, _tags) do
     nil
   end
 
-  def timing(_name, elapsed, _rate) do
+  def timing(_name, elapsed, _rate, _tags) do
     elapsed
   end
 
-  def histogram(_name, elapsed, _rate) do
+  def histogram(_name, elapsed, _rate, _tags) do
     elapsed
   end
 end

--- a/lib/plug_statsd/statix_backend.ex
+++ b/lib/plug_statsd/statix_backend.ex
@@ -1,7 +1,7 @@
 if Code.ensure_loaded?(Statix) do
   defmodule Plug.Statsd.StatixBackend do
     def increment(name, 1, tags) do
-      increment(name, 1.0, tags: tags)
+      increment(name, 1.0, tags)
     end
 
     def increment(name, rate, tags) when is_float(rate) do
@@ -9,14 +9,14 @@ if Code.ensure_loaded?(Statix) do
     end
 
     def timing(name, elapsed, 1, tags) do
-      timing(name, elapsed, 1.0, tags: tags)
+      timing(name, elapsed, 1.0, tags)
     end
 
     def timing(name, elapsed, rate, tags) when is_float(rate) do
       get_conn().timing(name, elapsed, sample_rate: rate, tags: tags)
     end
 
-    def histogram(name, elapsed, 1, tags), do: histogram(name, elapsed, 1.0, tags: tags)
+    def histogram(name, elapsed, 1, tags), do: histogram(name, elapsed, 1.0, tags)
 
     def histogram(name, elapsed, rate, tags) when is_float(rate) do
       get_conn().histogram(name, elapsed, sample_rate: rate, tags: tags)

--- a/lib/plug_statsd/statix_backend.ex
+++ b/lib/plug_statsd/statix_backend.ex
@@ -1,25 +1,25 @@
 if Code.ensure_loaded?(Statix) do
   defmodule Plug.Statsd.StatixBackend do
-    def increment(name, 1) do
-      increment(name, 1.0)
+    def increment(name, 1, tags) do
+      increment(name, 1.0, tags: tags)
     end
 
-    def increment(name, rate) when is_float(rate) do
-      get_conn().increment(name, 1, sample_rate: rate)
+    def increment(name, rate, tags) when is_float(rate) do
+      get_conn().increment(name, 1, sample_rate: rate, tags: tags)
     end
 
-    def timing(name, elapsed, 1) do
-      timing(name, elapsed, 1.0)
+    def timing(name, elapsed, 1, tags) do
+      timing(name, elapsed, 1.0, tags: tags)
     end
 
-    def timing(name, elapsed, rate) when is_float(rate) do
-      get_conn().timing(name, elapsed, sample_rate: rate)
+    def timing(name, elapsed, rate, tags) when is_float(rate) do
+      get_conn().timing(name, elapsed, sample_rate: rate, tags: tags)
     end
 
-    def histogram(name, elapsed, 1), do: histogram(name, elapsed, 1.0)
+    def histogram(name, elapsed, 1, tags), do: histogram(name, elapsed, 1.0, tags: tags)
 
-    def histogram(name, elapsed, rate) when is_float(rate) do
-      get_conn().histogram(name, elapsed, sample_rate: rate)
+    def histogram(name, elapsed, rate, tags) when is_float(rate) do
+      get_conn().histogram(name, elapsed, sample_rate: rate, tags: tags)
     end
 
     defp get_conn do

--- a/lib/plug_statsd/statsderl_backend.ex
+++ b/lib/plug_statsd/statsderl_backend.ex
@@ -1,10 +1,10 @@
 if Code.ensure_loaded?(:statsderl) do
   defmodule Plug.Statsd.StatsderlBackend do
-    def increment(name, rate) do
+    def increment(name, rate, _tags) do
       :statsderl.increment(name, 1, rate)
     end
 
-    def timing(name, elapsed, rate) do
+    def timing(name, elapsed, rate, _tags) do
       :statsderl.timing(name, elapsed, rate)
     end
   end


### PR DESCRIPTION
Adds the ability to associate tags with the metrics collected.  This is done either dynamically, by configuring a function to be called with `conn` and `opts` and return a list of tags, or statically, by configuring a list of tags.

I have only hooked up this new functionality for the statix back-end, however, it should not be very difficult for others to hook it up to the other back-ends as necessary. 